### PR TITLE
Missing pause at the end of help

### DIFF
--- a/main.py
+++ b/main.py
@@ -164,13 +164,13 @@ class HealthBoxTerminalWrapper: # contains various facilities for access to Heal
             print("    e 1")
             print("6. Set the API key type. If the API key will be used to submit data, set it's type as 'source' using this command: 't s'. If the API key will be used to read data, then set its type as 'app', using this command: 't a'.")
             print("7. Optionally, configure which metrics the API key can and can't access using the 'Security' and 'Filter' functions.")
-            print("8. Input the API key, HealthBox server address, and port into the application or device you'd like to configure.")
+            utils.pause_with_message("8. Input the API key, HealthBox server address, and port into the application or device you'd like to configure.")
         elif (selection == 2):
             print("To configure the default port number or database name of HealthBox, follow these instructions")
             print("1. Open `main.py` in the HealthBox folder in a text editor of your choice.")
             print("2. Locate the section at the top of the script labeled `----- Configuration -----`")
             print("3. Modify the values as desired")
-            pritn("4. Save `main.py` and exit")
+            utils.pause_with_message("4. Save `main.py` and exit")
         else:
             utils.pause_with_message("Invalid selection")
 


### PR DESCRIPTION
pritn instead of print

I don't know what you use as editor, but it seems there is ^M characters at the end of some lines.

All the code is not visible in Visual Studio Code as the lines between 170-174 ends with a ^M 

![image](https://user-images.githubusercontent.com/6904170/118968357-1bdce500-b96c-11eb-9b34-71ef36376c2d.png)

I changed the line with nano, but there is a ^M removed at the end of the line which is not visible in the github interface (gli git shows it correctly)

It seems there is no problem with this missing ^M